### PR TITLE
GDM-226: loading logo: define in entry point

### DIFF
--- a/example/src/main/java/org/geomajas/project/deskmanager/example/ExampleGeodeskEntryPoint.gwt.xml
+++ b/example/src/main/java/org/geomajas/project/deskmanager/example/ExampleGeodeskEntryPoint.gwt.xml
@@ -12,6 +12,9 @@
 
 	<inherits name="org.geomajas.project.deskmanager.example.ExampleCommonEntryPoint" />
 
+    <!-- Never use in production! IE11 problems -->
+    <!--<collapse-all-properties />-->
+
 	<entry-point class="org.geomajas.project.deskmanager.example.geodesk.client.ExampleGeodeskEntryPoint"/>
 
 	<source path="geodesk/client"/>

--- a/example/src/main/java/org/geomajas/project/deskmanager/example/ExampleManagerEntryPoint.gwt.xml
+++ b/example/src/main/java/org/geomajas/project/deskmanager/example/ExampleManagerEntryPoint.gwt.xml
@@ -8,6 +8,9 @@
 
 	<inherits name="org.geomajas.project.deskmanager.example.ExampleCommonEntryPoint" />
 
+    <!-- Never use in production! IE11 problems -->
+    <!--<collapse-all-properties />-->
+
 	<entry-point class="org.geomajas.project.deskmanager.example.manager.client.ExampleManagerEntryPoint"/>
 
     <set-property-fallback name="locale" value="en"/>

--- a/example/src/main/java/org/geomajas/project/deskmanager/example/common/client/DeskmanagerExampleCommonEntryPoint.java
+++ b/example/src/main/java/org/geomajas/project/deskmanager/example/common/client/DeskmanagerExampleCommonEntryPoint.java
@@ -11,6 +11,7 @@
 package org.geomajas.project.deskmanager.example.common.client;
 
 import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.GWT;
 import org.geomajas.plugin.deskmanager.client.gwt.common.GdmLayout;
 import org.geomajas.plugin.deskmanager.client.gwt.common.GeodeskIdUtil;
 
@@ -36,5 +37,7 @@ public class DeskmanagerExampleCommonEntryPoint implements EntryPoint {
 				return "../geodesk/index.html?geodesk=" + geodeskId;
 			}
 		};
+		//loading logo
+		GdmLayout.loadingLogo = GWT.getModuleBaseURL() + "images/Geomajas-Logo-Large.png";
 	}
 }

--- a/example/src/main/webapp/index.html
+++ b/example/src/main/webapp/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<meta HTTP-EQUIV="REFRESH" content="0; url=manager/index.html">
+</head>
+
+<body>
+</body>
+</html>

--- a/impl/src/main/java/org/geomajas/plugin/deskmanager/client/gwt/common/GdmLayout.java
+++ b/impl/src/main/java/org/geomajas/plugin/deskmanager/client/gwt/common/GdmLayout.java
@@ -86,9 +86,9 @@ public final class GdmLayout { // NOSONAR
 	public static int roleSelectZindex = Integer.MAX_VALUE;
 
 	/**
-	 * Default loading logo.
+	 * Logo shown on loading. By default: no logo.
 	 */
-	public static String loadingLogo = "/images/Geomajas-Logo-Large.png";
+	public static String loadingLogo;
 
 	/**
 	 * Version of the application.


### PR DESCRIPTION
Loading logo is in example module; 
GdmLayout.loadingLogo is in impl module (and cannot reference to example resource)

extra: add root index.html, redirecting to manager/index.html

compare http://dev.geomajas.org/geomajas-project-deskmanager-example-GDM-226_loadingLogo/
with http://dev.geomajas.org/geomajas-project-deskmanager-example-1.0.0-SNAPSHOT/manager/
